### PR TITLE
Add configuration manager. Now all the settings are in the config.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ _testmain.go
 
 # Idea
 .idea
+tilegenerator

--- a/app.go
+++ b/app.go
@@ -88,6 +88,5 @@ func getTile(writer http.ResponseWriter, req *http.Request) {
 	}
 	tile := mapobjects.NewTile(x, y, z)
 	writer.Header().Set("Content-Type", "image/svg+xml")
-	writer.WriteHeader(200)
 	svg.RenderTile(tile, &objects, writer)
 }

--- a/app.go
+++ b/app.go
@@ -18,7 +18,7 @@ import (
 var db database.GeometryDB
 
 func printStartingMsg(config *settings.Settings) {
-	fmt.Printf("Starting with settings:\n")
+	fmt.Printf("Starting with the following settings:\n")
 	fmt.Printf("\tGeometry table: %s\n", color.CyanString(config.DBGeometryTable))
 	fmt.Printf("\tGeometry column: %s\n", color.CyanString(config.DBGeometryColumn))
 	fmt.Printf("\tHTTP port: %s\n", color.CyanString(config.HTTPPort))

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 [database]
   connection_string = "host=localhost user=postgres dbname=testdb sslmode=disable"
-  geometry_table = "maps.maps_object"
+  geometry_table = "maps.maps_objects"
   geometry_column = "the_geom"
   instance_name = "postgres"
 

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,8 @@
+[database]
+  connection_string = "host=localhost user=postgres dbname=testdb sslmode=disable"
+  geometry_table = "maps.maps_object"
+  geometry_column = "the_geom"
+  instance_name = "postgres"
+
+[http]
+  port = "9081" 

--- a/database/database.go
+++ b/database/database.go
@@ -62,7 +62,7 @@ func (gdb *GeometryDB) GetAllPatrollingAreas() (geometries []geo.BaseGeometry, e
 	q := fmt.Sprintf("SELECT id, type_id, ST_AsText( ST_Transform( %s, 4326 ) ) from %s WHERE type_id = 47 OR type_id = 74;", gdb.geomcol, gdb.geomtable)
 	rows, err := gdb.conn.Query(q)
 	if err != nil {
-		fmt.Printf("Query error: %v", err)
+		fmt.Printf("Query error: %s\n", err.Error())
 	} else {
 		geometries := gdb.rowsToGeometries(rows)
 		return geometries, err

--- a/geo/geometry.go
+++ b/geo/geometry.go
@@ -1,17 +1,8 @@
 package geo
 
-import (
-	"github.com/paulsmith/gogeos/geos"
-)
-
 // BaseGeometry is a geometry structure
 type BaseGeometry struct {
 	ID     int
 	TypeID int
 	Value  string
-}
-
-// FromWKT parses WKT into a structure
-func (bg *BaseGeometry) FromWKT(wkt string) (*geos.Geometry, error) {
-	return geos.FromWKT(wkt)
 }

--- a/settings/manager.go
+++ b/settings/manager.go
@@ -1,0 +1,45 @@
+package settings
+
+import (
+	"fmt"
+	"github.com/pelletier/go-toml"
+	"sync"
+)
+
+// Settings is a singleton object, which contains configuration of a tile server
+type Settings struct {
+	DBConnectionString string
+	DBGeometryTable    string
+	DBGeometryColumn   string
+	DBInstanceName     string
+	HTTPPort           string
+}
+
+var instance *Settings
+var once sync.Once
+
+func readSettings() *Settings {
+	var settings Settings
+	config, err := toml.LoadFile("./config.toml")
+	if err != nil {
+		fmt.Println("Error ", err.Error())
+	} else {
+		settings = Settings{
+			DBConnectionString: config.Get("database.connection_string").(string),
+			DBGeometryTable:    config.Get("database.geometry_table").(string),
+			DBGeometryColumn:   config.Get("database.geometry_column").(string),
+			DBInstanceName:     config.Get("database.instance_name").(string),
+			HTTPPort:           config.Get("http.port").(string),
+		}
+	}
+	return &settings
+}
+
+// GetSettings returns single instance of the Settings structure.
+// By default it reads configuration from "config.toml" file
+func GetSettings() *Settings {
+	once.Do(func() {
+		instance = readSettings()
+	})
+	return instance
+}


### PR DESCRIPTION
An example of a default config

```toml
[database]
  connection_string = "host=localhost user=postgres dbname=testdb sslmode=disable"
  geometry_table = "maps.maps_objects"
  geometry_column = "the_geom"
  instance_name = "postgres"

[http]
  port = "9081" 
```